### PR TITLE
Correccion validacion campo Fotografia

### DIFF
--- a/label-studio-annotations-to-json-desafio.ipynb
+++ b/label-studio-annotations-to-json-desafio.ipynb
@@ -24,7 +24,7 @@
    },
    "outputs": [],
    "source": [
-    "label_studio_file = 'ROMINA_project-6-at-2023-04-13-20-03-88a115e6.json' #json desde Label Studio --> Export --> JSON List of items in raw JSON format stored in one JSON file. Use to export both the data and the annotations for a dataset. It's Label Studio Common Format\n",
+    "label_studio_file = 'NOMBRE_DE_ARCHIVO.json' #json desde Label Studio --> Export --> JSON List of items in raw JSON format stored in one JSON file. Use to export both the data and the annotations for a dataset. It's Label Studio Common Format\n",
     "df_full = pd.read_json(f'input/{label_studio_file}', encoding='utf-8')"
    ]
   },
@@ -188,12 +188,15 @@
     "        dict_data['h_pixels'] = round(df_groups.iloc[etiqueta]['value']['height'] / 100 * dict_data['h_ori'])\n",
     "        dict_data['label'] = df_groups.iloc[etiqueta]['value']['rectanglelabels'][0]\n",
     "        dict_data['grupo'] = df_groups.iloc[etiqueta]['grupo']\n",
-    "        try:\n",
-    "            dict_data['text'] = df_groups.iloc[etiqueta]['meta']['text'][0]\n",
-    "            dict_data['valido'] = True\n",
-    "        except:\n",
-    "            print(f\"Segmento sin texto -> Archivo {dict_data['image']}, Etiqueta {dict_data['label']}\")\n",
-    "            dict_data['valido'] = False\n",
+    "        if dict_data['label'] == 'Fotografía':\n",
+    "            dict_data['text'] = ''\n",
+    "        else:\n",
+    "            try:\n",
+    "                dict_data['text'] = df_groups.iloc[etiqueta]['meta']['text'][0]\n",
+    "                dict_data['valido'] = True\n",
+    "            except:\n",
+    "                print(f\"Segmento sin texto -> Archivo {dict_data['image']}, Etiqueta {dict_data['label']}\")\n",
+    "                dict_data['valido'] = False\n",
     "        \n",
     "        df_etiquetas = pd.concat([df_etiquetas, pd.DataFrame(data=dict_data, index=[index])])\n",
     "        index += 1"
@@ -239,14 +242,6 @@
     "    print('Archivo generado OK!')\n",
     "    print('==========================')"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "abbfb401-9a4a-40c5-95a4-e8f34ed57c26",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Ya no es necesario ingresar un texto "dummy" en el campo Meta para validar las etiquetas correspondientes a fotografías.